### PR TITLE
Fix DDNS GW check PHP error

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -2422,7 +2422,7 @@ function dyndnsCheckIP($int) {
 		$gateways_status = return_gateways_status(true);
 		// If the gateway for this interface is down, then the external check cannot work.
 		// Avoid the long wait for the external check to timeout.
-		if (stristr($gateways_status[config_get_path("interfaces/{$int}/gateway")], "down")) {
+		if (stristr(array_get_path($gateways_status, config_get_path("interfaces/{$int}/gateway") . "/status"), "down")) {
 			return "down";
 		}
 


### PR DESCRIPTION
We need to get the status value from the returned array, not use the array itself.

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [ ] Ready for review